### PR TITLE
Fix the order of OS_Parameter data

### DIFF
--- a/PreprocExport/Python/ImportPreprocessedData.py
+++ b/PreprocExport/Python/ImportPreprocessedData.py
@@ -25,8 +25,8 @@ def importPreprocessedData():
     preprocessedData = removeNanValues(preprocessedData,['OS_Parameters','Triggertimes','Triggervalues'])
     
     # Convert OS_Parameters to dataframe with parameter labels
-    parameterLabels = {str(attribute[0]).replace('b','') for attribute in importedData['OS_Parameters'].attrs['IGORWaveDimensionLabels'][1:]}
-    preprocessedData['OS_Parameters'] = pd.DataFrame(preprocessedData['OS_Parameters'].astype(int), index=parameterLabels,columns=['Value'])
+    parameterLabels = [str(attribute[0]).replace('b','') for attribute in importedData['OS_Parameters'].attrs['IGORWaveDimensionLabels'][1:]]    
+    preprocessedData['OS_Parameters'] = pd.DataFrame([value for value in importedData['OS_Parameters']], index=parameterLabels,columns=['Value'])
     
     #Convert Traces0_raw and Traces0_znorm to pandas dataframe with numbered ROIs
     preprocessedData = labelledDataframe(preprocessedData,['Traces0_znorm','Traces0_raw'])


### PR DESCRIPTION
up to now the OS_Parameter dictionary was being created, but there was a
mismatch in between the labels used and the values stores. Mainly
because the way the data was rearrenged relied on a "set" (which is an
unordered list) and a dictionary (which is also unordered). Now almost
the same code is used, but two lists are created, ensuring that the
labels will be assigned to the correct values. This fix makes the
python_float_fix obsolete.